### PR TITLE
Introduce a builder for `Atom`, to be used by input readers

### DIFF
--- a/data/molecule/atom.go
+++ b/data/molecule/atom.go
@@ -25,9 +25,10 @@ type _Atom struct {
 	Y float32 // Y-coordinate of this atom.
 	Z float32 // Z-coordinate of this atom.
 
-	hCount  uint8 // Number of implicit + explicit H atoms attached to this atom.
-	charge  int8  // Residual net charge of this atom.
-	valence int8  // Current valence configuration of this atom.
+	hCount  uint8       // Number of implicit + explicit H atoms attached to this atom.
+	charge  int8        // Residual net charge of this atom.
+	valence int8        // Current valence configuration of this atom.
+	radical cmn.Radical // Current radical configuration.
 
 	unsaturation cmn.Unsaturation // Current composite state of this atom.
 
@@ -62,11 +63,15 @@ type _Atom struct {
 
 // newAtom constructs and initialises a new atom of the given element
 // type, and belonging to the given molecule.
-func newAtom(mol *Molecule, atNum uint8) *_Atom {
+func newAtom(mol *Molecule, atNum uint8, iId int) *_Atom {
 	atom := new(_Atom)
 	atom.mol = mol
 	atom.atNum = atNum
-	atom.valence = cmn.PeriodicTable[cmn.ElementSymbols[atNum]].Valence
+	atom.iId = uint16(iId)
+
+	el := cmn.PeriodicTable[cmn.ElementSymbols[atNum]]
+	atom.symbol = el.Symbol
+	atom.valence = el.Valence
 
 	atom.bonds = bits.New(cmn.MaxBonds)
 	atom.nbrs = make([]uint16, 0, cmn.MaxBonds)

--- a/data/molecule/atom_builder.go
+++ b/data/molecule/atom_builder.go
@@ -1,0 +1,85 @@
+package molecule
+
+import (
+	"fmt"
+
+	cmn "github.com/RxnWeaver/rxnweaver/common"
+)
+
+// AtomBuilder builds an atom, in typical builder fashion, one
+// property at a time.
+//
+// This type is public.  This is the only way to create a new atom
+// from outside this package.  The created and constructed atom can
+// NOT be extracted or used directly.  The only way to make use of it
+// is to send it to a molecule for inclusion in it.
+//
+// An instance of builder can create and build only one atom.
+type AtomBuilder struct {
+	a *_Atom // Atom being built by this builder.
+}
+
+// NewAtomBuilder answers a new atom builder.
+func NewAtomBuilder() *AtomBuilder {
+	return &AtomBuilder{}
+}
+
+// New creates a new atom instance in this builder.
+func (ab *AtomBuilder) New(iId int, sym string) (*AtomBuilder, error) {
+	if iId <= 0 {
+		return nil, fmt.Errorf("Input ID of an atom must be positive; given : %d", iId)
+	}
+
+	el, ok := cmn.PeriodicTable[sym]
+	if !ok {
+		return nil, fmt.Errorf("Unknown symbol : %s", sym)
+	}
+
+	// The molecule, in which this atom gets eventually included,
+	// should set itself as the containing molecule.
+	ab.a = newAtom(nil, el.Number, iId)
+	return ab, nil
+}
+
+// Coordinates sets the given coordinates as the X-, Y- and
+// Z-coordinates of this atom.
+func (ab *AtomBuilder) Coordinates(x, y, z float32) *AtomBuilder {
+	a := ab.a
+	a.X = x
+	a.Y = y
+	a.Z = z
+	return ab
+}
+
+// Charge sets the residual charge on this atom.
+func (ab *AtomBuilder) Charge(ch int) *AtomBuilder {
+	switch ch {
+	case 1:
+		ab.a.charge = int8(3)
+	case 2:
+		ab.a.charge = int8(2)
+	case 3:
+		ab.a.charge = int8(1)
+	case 4:
+		ab.a.radical = cmn.RadicalDoublet
+	case 5:
+		ab.a.charge = int8(-1)
+	case 6:
+		ab.a.charge = int8(-2)
+	case 7:
+		ab.a.charge = int8(-3)
+	default:
+		ab.a.charge = int8(0)
+	}
+
+	return ab
+}
+
+// Valence sets the current valence configuration of this atom.
+func (ab *AtomBuilder) Valence(v int) *AtomBuilder {
+	if v > 0 && v < 15 {
+		ab.a.valence = int8(v)
+	}
+
+	return ab
+}


### PR DESCRIPTION
This has a bias towards `.mol` MDL format, in particular the V2000 format.  This may have to be reviewed at a suitable point of time.
